### PR TITLE
Add Support for Blockquotes, Headings, and styling for <a>

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,3 +1,11 @@
+:root {
+  --clip-bottom-right: polygon(100% 0,100% calc(100% - 15px),calc(100% - 15px) 100%,0 100%,0 0);
+
+  --white: #FFF;
+  --primary: #991E2A;
+  --primary-accent: #D93F4E;
+}
+
 .App {
   text-align: center;
 }
@@ -13,16 +21,6 @@
   }
 }
 
-.App-header {
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-}
-
 .App-link {
   color: #61dafb;
 }
@@ -31,4 +29,43 @@
   100% {
     background-position: -3000px -3000px;
   }
+}
+
+.md-blockquote {
+  display: flex;
+  margin: 0 40px;
+  padding: 0 1rem;
+  border-left: 1px solid rgb(128, 128, 128);
+}
+
+.md-blockquote > *:first-child {
+  margin: 0;
+}
+
+.heading {
+  padding: 5px 1.5rem;
+  display: flex;
+  max-width: fit-content;
+  color: var(--white);
+  background-color: var(--primary);
+  clip-path: var(--clip-bottom-right);
+  -webkit-clip-path: var(--clip-bottom-right);
+}
+
+h2.heading {
+  font-size: 32px;
+  text-transform: uppercase;
+}
+
+h3.heading {
+  font-size: 24px;
+}
+
+a {
+  color: var(--primary-accent);
+  font-weight: bold;
+}
+
+a:visited {
+  color: var(--primary);
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,18 +4,23 @@ import Article from "./components/Article";
 import CautionTape from "./components/CautionTape";
 import Grid from "./assets/background-grid.png";
 
-const page = "subfile";
+const page = "Court 6";
 
 const WIP_MODE = false;
 
 function App() {
 
-  const [markdown, setMarkdown] = useState("");
+  const [markdown, setMarkdown] = useState<string|undefined>();
 
   useEffect(() => {
     if (!WIP_MODE) {
       fetch(`markdown/${page}.md`, {headers: {'Content-Type': 'text/markdown', 'Accept': 'text/markdown'}})
-        .then((res) => res.text())
+        .then((res) => {
+          if (res.ok || res.redirected) {
+            return res.text();
+          }
+          return;
+        })
         .then((text) => setMarkdown(text));
     }
   }, [page]);
@@ -25,14 +30,14 @@ function App() {
       className="App"
       style={{
         width: "100%",
-        height: "100vh",
+        height: "100%",
         background: `url(${Grid}`,
         "animation": "scroll 600s linear infinite",
         top: 0,
         left: 0,
       }}
     >
-      <header className="App-header">
+      <header>
         {WIP_MODE
           ? <CautionTape text={"Under Construction"}/>
           : <Article text={markdown}/>

--- a/src/components/Article.tsx
+++ b/src/components/Article.tsx
@@ -1,11 +1,28 @@
 import React from "react";
 import Markdown from "react-markdown";
+import Blockquote from "./markdown/blockquote";
+import Heading from "./markdown/heading";
 
-function Article({ text }: { text:string }) {
+function Article({ text }: { text:(string|undefined) }) {
 
   return (
-    <div style={{ backgroundColor: "white", border: "1px dashed #991e2a", color: "black" }}>
-      <Markdown children={text}/>
+    <div style={{ border: "1px dashed #991e2a", color: "black", textAlign: "left" }}>
+      {text != null
+        ? (
+          <Markdown
+            components={{
+              blockquote: Blockquote,
+              h1: Heading,
+              h2: Heading,
+              h3: Heading,
+              h4: Heading,
+            }}
+          >
+            {text}
+          </Markdown>
+        )
+        : "Content could not be found."
+      }
     </div>
   )
 }

--- a/src/components/CautionTape.tsx
+++ b/src/components/CautionTape.tsx
@@ -5,8 +5,8 @@ function CautionTape({ text }:{ text:string }) {
     <div
       style={{
         backgroundColor: "#991e2a",
-        "clipPath": "polygon(100% 0,100% calc(100% - 15px),calc(100% - 15px) 100%,0 100%,0 0)",
-        WebkitClipPath: "polygon(100% 0,100% calc(100% - 15px),calc(100% - 15px) 100%,0 100%,0 0)",
+        clipPath: "var(--clip-bottom-right)",
+        WebkitClipPath: "var(--clip-bottom-right)",
         fontSize: 60,
         padding: 30,
         fontWeight: 600,

--- a/src/components/markdown/blockquote.tsx
+++ b/src/components/markdown/blockquote.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { ExtraProps } from "react-markdown";
+
+type blockquoteProps = React.ClassAttributes<HTMLQuoteElement> & React.BlockquoteHTMLAttributes<HTMLQuoteElement> & ExtraProps
+
+function Blockquote(props:blockquoteProps){
+
+  const { children} = props;
+  return (
+    <blockquote className={"md-blockquote"} >
+      {children}
+    </blockquote>
+  );
+}
+
+export default Blockquote;

--- a/src/components/markdown/heading.tsx
+++ b/src/components/markdown/heading.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { ExtraProps } from "react-markdown";
+
+type headingProps = React.ClassAttributes<HTMLHeadingElement> & React.HTMLAttributes<HTMLHeadingElement> & ExtraProps;
+
+function Heading(props:headingProps) {
+  const { children, ...rest } = props;
+  const HeadingTag = props.node?.tagName || "h2";
+  // TODO: Figure out the proper TS way to do this, not just ts-ignore
+  // @ts-ignore
+  return <HeadingTag {...rest} className={"heading"} >{children}</HeadingTag>;
+}
+
+export default Heading;


### PR DESCRIPTION
Adds a custom component for Blockquotes and Headings (h1, h2, etc...). Additionally, adds css styling for <a> tags, although a custom component will be added for them in a future PR.